### PR TITLE
fix path to version

### DIFF
--- a/hammer_cli_import.gemspec
+++ b/hammer_cli_import.gemspec
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
 
-require 'lib/hammer_cli_import/version'
+require 'hammer_cli_import/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'hammer_cli_import'


### PR DESCRIPTION
corrects:
gem build hammer_cli_import.gemspec 
Invalid gemspec in [hammer_cli_import.gemspec]: cannot load such file -- lib/hammer_cli_import/version
ERROR:  Error loading gemspec. Aborting.
