### PR TITLE
Update hammer_cli_import.gemspec

### DIFF
--- a/hammer_cli_import.gemspec
+++ b/hammer_cli_import.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files = []
 
   spec.add_dependency('hammer_cli')
-  spec.add_dependency('hammer_cli_foreman', '~> 0.1.1')
+  spec.add_dependency('hammer_cli_foreman', '> 0.1.1')
   spec.add_dependency('hammer_cli_katello', '~> 0.0.6')
 end


### PR DESCRIPTION
The gemspec prevents the loading of the hammer_cli_import module, since hammer_cli_foreman is now on the 0.2.x version range.

[ERROR 2015-05-07 11:09:08 Modules] <Gem::LoadError> Unable to activate hammer_cli_import-0.10.12, because hammer_cli_foreman-0.2.0 conflicts with hammer_cli_foreman (~> 0.1.1)