### PR TITLE
Bug 1291690 - hammer import refers to an internal name

### DIFF
--- a/lib/hammer_cli_import/all.rb
+++ b/lib/hammer_cli_import/all.rb
@@ -31,7 +31,7 @@ module HammerCLIImport
       command_name 'all'
       desc 'Load ALL data from a specified directory that is in spacewalk-export format.'
 
-      option ['--directory'], 'DIR_PATH', 'stargate-export directory', :default => '/tmp/exports'
+      option ['--directory'], 'DIR_PATH', 'The directory where the export file was extracted', :default => '/tmp/exports'
       option ['--delete'], :flag, 'Delete entities instead of importing them', :default => false
       option ['--macro_mapping'], 'FILE', 'Mapping of Satellite-5 config-file-macros to puppet facts'
       option ['--manifest-directory'], 'DIR_PATH', 'Directory holding manifests'


### PR DESCRIPTION
hammer import all --delete --help referred to "stargate-export
directory". Updated to be generic.